### PR TITLE
プロフィールの編集と住所の編集の実装

### DIFF
--- a/app/assets/stylesheets/modules/mypage_mainarea.scss
+++ b/app/assets/stylesheets/modules/mypage_mainarea.scss
@@ -123,5 +123,47 @@
         color: $white;
       }
     }
+
+    // -if @path.is('users#edit')
+    .useredit-form, .addressedit-form {
+      height: auto;
+      width: 100%;
+      background-color: $white;
+      padding: 0 150px 40px;
+      .form-label {
+        display: inline-block;
+        font-size: 14px;
+        font-weight: bold;
+        margin-top: 32px;
+      }
+      p {
+        display: inline-block;
+        font-size: 0.75em;
+        padding: 2px 4px;
+        background-color: $red;
+        border-radius: 4px;
+        color: $white;
+        margin-left: 5px;
+      }
+      p.gray {
+        background-color: $lightGray;
+      }
+      .text {
+        height: 50px;
+        width: 100%;
+        border: 1px solid $bordergray;
+        border-radius: 5px;
+        padding: 10px 16px;
+        margin-top: 10px;
+      }
+      .update-btn {
+        height: 50px;
+        width: 100%;
+        background-color: $mainBlue;
+        margin-top: 60px;
+        color: $white;
+        font-weight: bold;
+      }
+    }
   }
 }

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -10,9 +10,13 @@ class AddressesController < ApplicationController
   end
 
   def edit
+    @address = Address.find_by(user_id: current_user.id)
   end
 
   def update
+    @address = Address.find_by(user_id: current_user.id)
+    @address.update(address_params)
+    redirect_to user_path(current_user.id)
   end
 
   private

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -15,8 +15,11 @@ class AddressesController < ApplicationController
 
   def update
     @address = Address.find_by(user_id: current_user.id)
-    @address.update(address_params)
-    redirect_to user_path(current_user.id)
+    if @address.update(address_params)
+      redirect_to user_path(current_user.id)
+    else
+      redirect_to edit_address_path(current_user.id)
+    end
   end
 
   private

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -9,6 +9,12 @@ class AddressesController < ApplicationController
     redirect_to user_path(current_user.id)
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   private
 
   def address_params

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,4 +1,6 @@
 class AddressesController < ApplicationController
+  before_action :set_current_address, only: [:edit, :update]
+
   def new
     @address = Address.new
   end
@@ -10,11 +12,9 @@ class AddressesController < ApplicationController
   end
 
   def edit
-    @address = Address.find_by(user_id: current_user.id)
   end
 
   def update
-    @address = Address.find_by(user_id: current_user.id)
     if @address.update(address_params)
       redirect_to user_path(current_user.id)
     else
@@ -23,6 +23,10 @@ class AddressesController < ApplicationController
   end
 
   private
+
+  def set_current_address
+    @address = Address.find_by(user_id: current_user.id)
+  end
 
   def address_params
     params.require(:address).permit(:postal_code, :prefectures, :municipalities, :address, :building).merge(user_id: current_user.id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,14 +6,24 @@ class UsersController < ApplicationController
   end
 
   def edit
+    @user = User.find(current_user.id)
   end
 
   def update
+    @user = User.find(current_user.id)
+    @user.update(user_params)
+    redirect_to user_path(current_user.id)
   end
 
   def before_logout
   end
 
+
+  private
+
+  def user_params
+    params.require(:user).permit(:nickname, :email, :family_name, :last_name, :family_name_kana, :last_name_kana, :phone_number)
+  end
 
 
   # Payjp.api_key = PAYJP_SECRET_KEY = 'sk_test_fc909327daf398b939d901a1'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,8 +5,16 @@ class UsersController < ApplicationController
     @address = Address.find_by(user_id: current_user.id)
   end
 
+  def edit
+  end
+
+  def update
+  end
+
   def before_logout
   end
+
+
 
   # Payjp.api_key = PAYJP_SECRET_KEY = 'sk_test_fc909327daf398b939d901a1'
   # customer = Payjp::Customer.create(card: params[:payjp_token])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,16 +1,15 @@
 class UsersController < ApplicationController
-  before_action :move_to_show, only: :destroy
+  # before_action :move_to_show, only: :destroy
+  before_action :set_current_user, only: [:show, :edit, :update]
+
   def show
-    @user = User.find(current_user.id)
     @address = Address.find_by(user_id: current_user.id)
   end
 
   def edit
-    @user = User.find(current_user.id)
   end
 
   def update
-    @user = User.find(current_user.id)
     if @user.update(user_params)
       redirect_to user_path(current_user.id)
     else
@@ -24,6 +23,10 @@ class UsersController < ApplicationController
 
 
   private
+
+  def set_current_user
+    @user = User.find(current_user.id)
+  end
 
   def user_params
     params.require(:user).permit(:nickname, :email, :family_name, :last_name, :family_name_kana, :last_name_kana, :phone_number)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,9 +11,13 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(current_user.id)
-    @user.update(user_params)
-    redirect_to user_path(current_user.id)
+    if @user.update(user_params)
+      redirect_to user_path(current_user.id)
+    else
+      redirect_to edit_user_path(current_user.id)
+    end
   end
+
 
   def before_logout
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   has_one :address, dependent: :destroy
-  validates :password, presence: true, length: { minimum: 7 }
   VALID_ZENKAKU_REGEX = /\A[ぁ-んァ-ン一-龥]/
   validates :family_name, :last_name, :family_name_kana, :last_name_kana, format: { with: VALID_ZENKAKU_REGEX}
   # https://qiita.com/takeoverjp/items/bb56d6a8eae191cd3732

--- a/app/views/addresses/edit.html.haml
+++ b/app/views/addresses/edit.html.haml
@@ -1,0 +1,3 @@
+= render "top/header"
+= render "users/mypage_mainarea"
+= render "top/footer"

--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -40,7 +40,7 @@
           .signup-form__group
             .signup-form__group__title
               = f.label :building, class: "signup-form__group__title__label" do
-                番地
+                建物名など
               %span.signup-form__group__title__optional
                 任意
             = f.text_field :building, class: "signup-form__group__input", placeholder: "例) フレーム神南坂401"

--- a/app/views/devise/registrations/_sign-up.html.haml
+++ b/app/views/devise/registrations/_sign-up.html.haml
@@ -16,7 +16,7 @@
             ニックネーム
           %span.signup-form__group__title__required
             必須
-        = f.text_field :nickname, class: "signup-form__group__input", placeholder: "例) フリマ太郎" 
+        = f.text_field :nickname, class: "signup-form__group__input", placeholder: "例) フリマ太郎"
       .signup-form__group
         .signup-form__group__title
           = f.label :email, class: "signup-form__group__title__label" do

--- a/app/views/top/_header.html.haml
+++ b/app/views/top/_header.html.haml
@@ -17,10 +17,11 @@
           カテゴリー
         %li.sideHeader__left--items
           ブランド
-      %ul.sideHeader__right
-        %li.sideHeader__right--log
-          = link_to new_user_session_path ,class: 'login-btn' do
-            ログイン
-        %li.sideHeader__right--new
-          = link_to new_user_registration_path ,class: 'new-btn' do
-            新規会員登録
+      -if @path.is('top#index')
+        %ul.sideHeader__right
+          %li.sideHeader__right--log
+            = link_to new_user_session_path ,class: 'login-btn' do
+              ログイン
+          %li.sideHeader__right--new
+            = link_to new_user_registration_path ,class: 'new-btn' do
+              新規会員登録

--- a/app/views/users/_mypage_leftbox.html.haml
+++ b/app/views/users/_mypage_leftbox.html.haml
@@ -29,7 +29,7 @@
       プロフィール編集
   =link_to edit_address_path(current_user.id) do
     %p
-      住所変更
+      住所編集
   =link_to before_logout_users_path do
     %p
       ログアウト

--- a/app/views/users/_mypage_leftbox.html.haml
+++ b/app/views/users/_mypage_leftbox.html.haml
@@ -21,13 +21,15 @@
   =link_to user_path(current_user.id) do
     %p
       プロフィール
-  %p
-    発送元・お届け先住所変更
   = link_to cards_path, method: :get do
     %p
       支払い方法
-  %p
-    プロフィール編集
+  =link_to edit_user_path(current_user.id) do
+    %p
+      プロフィール編集
+  =link_to edit_address_path(current_user.id) do
+    %p
+      住所変更
   =link_to before_logout_users_path do
     %p
       ログアウト

--- a/app/views/users/_mypage_mainarea.html.haml
+++ b/app/views/users/_mypage_mainarea.html.haml
@@ -93,3 +93,105 @@
             ¥
             = item.price
 
+    -if @path.is('users#edit')
+      %p.title
+        プロフィールを編集する
+      = form_with(model: @user, url: user_path(current_user.id), method: :patch, class: 'useredit-form', local: true) do |f|
+        - if @user.errors.any?
+          .error
+            %h2= "#{@user.errors.full_messages.count}件のエラーが発生しました。"
+            %ul
+              - @user.errors.full_messages.each do |message|
+                %li= message
+
+        = f.label :nickname, class: "form-label" do
+          ニックネーム
+        %p
+          必須
+        = f.text_field :nickname, class: "text", placeholder: "例) フリマ太郎"
+
+        = f.label :email, class: "form-label" do
+          メールアドレス
+        %p
+          必須
+        = f.text_field :email, class: "text", placeholder: "PC・携帯どちらでも可"
+
+        = f.label :family_name, class: "form-label" do
+          姓 (全角)
+        %p
+          必須
+        = f.text_field :family_name, class: "text", placeholder: "例）山田"
+
+        = f.label :last_name, class: "form-label" do
+          名 (全角)
+        %p
+          必須
+        = f.text_field :last_name, class: "text", placeholder: "例）綾"
+
+        = f.label :family_name_kana, class: "form-label" do
+          姓 (カナ)
+        %p
+          必須
+        = f.text_field :family_name_kana, class: "text", placeholder: "例）ヤマダ"
+
+        = f.label :last_name_kana, class: "form-label" do
+          名 (カナ)
+        %p
+          必須
+        = f.text_field :last_name_kana, class: "text", placeholder: "例）アヤ"
+
+        = f.label :phone_number, class: "form-label" do
+          電話番号
+        %p.gray
+          任意
+        = f.text_field :phone_number, class: "text", placeholder: "例）123-4567-8910"
+
+        = f.submit "プロフィールを更新する", class: "update-btn"
+
+    
+    -if @path.is('addresses#edit')
+      %p.title
+        住所を編集する
+      = form_with(model: @address, url: address_path(@address.id), method: :patch, class: 'addressedit-form', local: true) do |f|
+        - if @address.errors.any?
+          .error
+            %h2= "#{@address.errors.full_messages.count}件のエラーが発生しました。"
+            %ul
+              - @address.errors.full_messages.each do |message|
+                %li= message
+
+        = f.label :postal_code, class: "form-label" do
+          郵便番号
+        %p
+          必須
+        = f.text_field :postal_code, class: "text", placeholder: "例) 1500041"
+
+        = f.label :prefectures, class: "form-label" do
+          都道府県
+        %p
+          必須
+        = f.text_field :prefectures, class: "text", placeholder: "例) 東京都"
+
+        = f.label :municipalities, class: "form-label" do
+          市区町村
+        %p
+          必須
+        = f.text_field :municipalities, class: "text", placeholder: "例) 渋谷区"
+
+        = f.label :address, class: "form-label" do
+          番地
+        %p
+          必須
+        = f.text_field :address, class: "text", placeholder: "例) 神南１丁目１８−２"
+
+        = f.label :building, class: "form-label" do
+          建物名など
+        %p.gray
+          任意
+        = f.text_field :building, class: "text", placeholder: "例) フレーム神南坂401"
+
+        = f.submit "住所を更新する", class: "update-btn"
+
+
+
+

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,3 @@
+= render "top/header"
+= render "users/mypage_mainarea"
+= render "top/footer"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -166,7 +166,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: 'top#index'
   devise_for :users, controllers: { registrations: 'users/registrations' }
   resources :top, only: [:new, :create]
-  resources :users, only: :show do
+  resources :users, only: [:show, :edit, :update] do
     collection do
       get 'before_logout'
     end
@@ -14,5 +14,5 @@ Rails.application.routes.draw do
     end
   end
   resources :cards, only: [:create, :show, :index, :new] 
-  resources :addresses, only: [:new, :create]
+  resources :addresses, only: [:new, :create, :edit, :update]
 end


### PR DESCRIPTION
#what
マイページからプロフィールの編集と住所の編集をできるようにしました。

#why
登録した自分の情報を編集できる機能がなければ、ユーザーの状況に合わせたサービスの提供ができません。
ユーザーの状況が変わっても、その状況を再度登録できるようにしました。

マイページからプロフィール編集画面への遷移gif
https://gyazo.com/b085de7a7228f7c990506d745f4cd7ab
プロフィール編集gif
https://gyazo.com/b8d60db576165ca0f16ac3d228106ce7

マイページから住所編集画面への遷移gif
https://gyazo.com/2131cddbd18e97fe0b4a3695207afadf
住所編集gif
https://gyazo.com/dfe452b30990d578494d4bf7bba1be51

よろしくお願いします。