### PR TITLE
カテゴリー機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.4.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,8 +13,9 @@
 //= require rails-ujs
 //= require activestorage
 
-//= require_tree .
+
 //= require jquery 
 //= require jquery.turbolinks
-//= require turbolinks
 //= require jquery_ujs 
+
+//= require_tree .

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,41 @@
+$(function(){
+  // カテゴリーセレクトボックスのオプションを作成
+  function appendOption(category){
+    var html = `<option value="${category.id}">${category.name}</option>`;
+    return html;
+  }
+  // 子カテゴリーの表示作成
+  function appendChidrenBox(insertHTML){
+    var childSelectHtml = '';
+    childSelectHtml = `<select id="child_category" name="item[category_id]">
+                        <option value="---">---</option>
+                        ${insertHTML}
+                      <select>`;
+    $('.category-box').append(childSelectHtml);
+  }
+  // 親カテゴリー選択後のイベント
+  $('#item_category_id').on('change', function(){
+    var parentValue = document.getElementById('item_category_id').value; //選択された親カテゴリーの名前を取得
+    if (parentValue !== 1){ //親カテゴリーが初期値でないことを確認
+      $.ajax({
+        url: '/items/children_category',
+        type: 'GET',
+        data: { parent_id: parentValue },
+        dataType: 'json'
+      })
+      .done(function(children){
+        $('#child_category').remove(); //親が変更された時、子を削除
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+        appendChidrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリー取得に失敗しました');
+      })
+    }else{
+      $('#child_category').remove(); //親カテゴリーが初期値になった時、子を削除
+    }
+  });
+});

--- a/app/assets/stylesheets/modules/item-sale-page.scss
+++ b/app/assets/stylesheets/modules/item-sale-page.scss
@@ -106,8 +106,11 @@
         color: $fontGray;
       }
       .right-box {
-        height: 180px;
+        height: auto;
         width: 400px;
+        .category-box {
+          margin-bottom: 40px;
+        }
         .title {
           font-size: 14px;
           font-weight: bold;
@@ -126,9 +129,6 @@
           border-radius: 4px;
           border: 1px solid $lightGray;
           margin-top: 8px;
-        }
-        select#item_category_id {
-          margin-bottom: 40px;
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,10 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def children_category
+    @children = Category.find(params[:parent_id]).children
+  end
+
   def create
     @item = Item.new(item_params)
     if @item.save

--- a/app/views/items/children_category.json.jbuilder
+++ b/app/views/items/children_category.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -36,12 +36,12 @@
         %p
           商品の詳細
         .right-box
-          = f.label :category_id, class: "title" do
-            カテゴリー
-            %span
-              必須
-          -# = f.select :category_id, Category.where(ancestry: nil).map { |category| [category.name, category.id] }
-          = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name
+          .category-box
+            = f.label :category_id, class: "title" do
+              カテゴリー
+              %span
+                必須
+            = f.collection_select :category_id, Category.where(ancestry: nil), :id, :name
           = f.label :status_id, class: "title" do
             商品の状態
             %span

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,7 +6,9 @@
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,8 +6,6 @@
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     collection do
       get 'saling_show'
       get 'saled_show'
+      get 'children_category', defaults: { format: 'json' }
     end
   end
 


### PR DESCRIPTION
#what
アイテム出品時に、そのアイテムにカテゴリーが付けられるようにしました。
itemsテーブルにはcategory_idカラムがあります。また、categoriesテーブルではancestryを用いて、親カテゴリーと子カテゴリーを管理しています。また、親カテゴリーが選択されると子カテゴリーセレクトボックスが非同期で出現。選択肢も選択された親カテゴリーによって変化します。

#why
カテゴリーによる検索機能は、今回は実装するか否かは未定です。しかし、アイテムにカテゴリーを付けることができれば、アイテムを検索する方法が増えて、求めるアイテムがヒットしやすくなります。

子カテゴリー出現gif
https://gyazo.com/7fdc161d3ca4f57dedd6a8c28033dc79

itemsテーブルに登録　id =11,12注目
https://gyazo.com/cb20a7a6adb8a9aa15a7a4d39baec1ca

categoriesテーブル
https://gyazo.com/2d2ab305b757a528c792bc1210216627

よろしくお願い致します。