### PR TITLE
クレジットカード未登録で、商品を購入しようとした場合、カード登録ページにリダイレクト。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -54,11 +54,16 @@ class ItemsController < ApplicationController
 
 
   def before_buy
-    @image = Image.find_by(item_id: @item.id)
-    @address = Address.find_by(user_id: current_user.id)
-    @card = Card.find_by(user_id: current_user.id)
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-    @card_information = customer.cards.retrieve(@card.card_id)
+    @user = User.find(current_user.id)
+    if @user.cards.exists?
+      @image = Image.find_by(item_id: @item.id)
+      @address = Address.find_by(user_id: current_user.id)
+      @card = Card.find_by(user_id: current_user.id)
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @card_information = customer.cards.retrieve(@card.card_id)
+    else
+      redirect_to new_card_path
+    end
   end
 
 

--- a/app/views/items/_itemContentBox.html.haml
+++ b/app/views/items/_itemContentBox.html.haml
@@ -15,8 +15,8 @@
           = link_to edit_item_path(@item.id),class:"itemEdit-Purchase__btn"do
             編集する
       - else
-        .itemEdit-Purchase
-          = link_to before_buy_item_path(@item.id) ,class:"itemEdit-Purchase__btn" do
+        = link_to before_buy_item_path(@item.id) ,class:"itemEdit-Purchase__btn" do
+          .itemEdit-Purchase
             購入する
 - else
   


### PR DESCRIPTION
#what
クレジットカード未登録で、商品を購入しようとした場合、カード登録ページにリダイレクトさせました。

#why
商品購入確認ページでは、登録してあるカードを表示させています。
未登録の状態でそのページに行くと、当然ながらエラーが出てきます。そのエラーを防ぐためと購入前に確実にクレジットカードを登録している状態にしたいため、上記の機能を実装しました。