### PR TITLE
マイページからクレジットカードの編集(詳細表示、削除)

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -19,7 +19,7 @@ class CardsController < ApplicationController
       if @card.save
         redirect_to card_path([000], id: show)
       else
-        redirect_to card_path
+        redirect_to cards_path
       end
     end
   end

--- a/app/views/users/_mypage_leftbox.html.haml
+++ b/app/views/users/_mypage_leftbox.html.haml
@@ -22,8 +22,11 @@
     %p
       プロフィール
   = link_to cards_path, method: :get do
-    %p
-      支払い方法
+    %p 
+      クレジットカード登録
+  = link_to card_path(current_user.id) do
+    %p 
+      クレジットカード編集   
   =link_to edit_user_path(current_user.id) do
     %p
       プロフィール編集


### PR DESCRIPTION
#What
ユーザーマイページからクレジットカードの追加、削除ができるように。
#Why 
以前の仕様ではクレジットカードの登録後しかクレジットカードの詳細表示、削除が出来なかったが
クレジットカードの編集項目を新たに設け、いつでもマイページから削除、詳細を見れるように。