### PR TITLE
商品購入機能の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -78,7 +78,7 @@ class ItemsController < ApplicationController
     )
     @item.buyer_id = current_user.id
     @item.save
-    redirect_to user_path(current_user.id)
+    redirect_to root_path
   end
 
   def destroy

--- a/app/views/items/_itemContentBox.html.haml
+++ b/app/views/items/_itemContentBox.html.haml
@@ -14,7 +14,7 @@
         = link_to edit_item_path(@item.id),class:"itemEdit-Purchase__btn"do
           .itemEdit-Purchase         
             編集する
-      - else
+      - if @item.buyer_id == nil
         = link_to before_buy_item_path(@item.id) ,class:"itemEdit-Purchase__btn" do
           .itemEdit-Purchase
             購入する


### PR DESCRIPTION
#What
商品購入機能の修正
#Why
購入完了時にマイページに遷移していたがトップページに遷移出来るように表示。
購入した商品が過去の取引商品から何度も買えてしまう使用を購入後は購入ボタンを表示させなくした。
